### PR TITLE
build: add install-lint make target

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,12 +9,13 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -41,7 +41,7 @@ jobs:
           go mod download -modfile tools/go.mod
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.0
+        run: make install-lint
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ buildctl-release:
 lint:
 	golangci-lint run --fix
 
+install-lint:
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+
 govulncheck:
 	go tool -modfile tools/go.mod govulncheck ./...
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ LOCKSMITH_METRICS_PORT ?= 9464
 LOCKSMITH_OBSERVABILITY ?= true
 
 CTL_BIN_NAME ?= locksmithctl
+GOPATH ?= $(shell go env GOPATH)
+GOBIN ?= $(GOPATH)/bin
 
 .PHONY: build
 build:
@@ -24,7 +26,7 @@ lint:
 	golangci-lint run --fix
 
 install-lint:
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
 
 govulncheck:
 	go tool -modfile tools/go.mod govulncheck ./...


### PR DESCRIPTION
## Summary
- add an `install-lint` Makefile target using the same golangci-lint install command now used in kerberos
- make it easy to install the lint tool locally before running the repo workflows and checks