### PR TITLE
Split Go module and build caches

### DIFF
--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -33,19 +33,38 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: build-${{ steps.checksum.outputs.checksum }}
-          restore-keys: build-
+          restore-keys: |
+            build-
 
       - name: Build server binary
         run: make build
 
       - name: Build CLI binary
         run: make buildctl
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -35,14 +35,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: build-${{ steps.checksum.outputs.checksum }}
@@ -57,14 +57,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -37,15 +37,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: build-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: build-${{ steps.checksum.outputs.checksum }}
+          key: build-go-build-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            build-
+            build-go-build-
 
       - name: Build server binary
         run: make build

--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -33,16 +33,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: build-${{ steps.checksum.outputs.checksum }}
@@ -54,17 +52,3 @@ jobs:
 
       - name: Build CLI binary
         run: make buildctl
-
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: integration-test-${{ steps.checksum.outputs.checksum }}
@@ -61,14 +61,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: integration-test-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -37,16 +37,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: integration-test-${{ steps.checksum.outputs.checksum }}
@@ -59,19 +57,6 @@ jobs:
       - name: Run integration tests
         run: make integration-test-json
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: integration-test-${{ steps.checksum.outputs.checksum }}
 
       - name: Publish integration test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -37,22 +37,41 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: integration-test-${{ steps.checksum.outputs.checksum }}
-          restore-keys: integration-test-
+          restore-keys: |
+            integration-test-
 
       - name: Run test environment
         run: make compose
 
       - name: Run integration tests
         run: make integration-test-json
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: integration-test-${{ steps.checksum.outputs.checksum }}
 
       - name: Publish integration test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -41,15 +41,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: integration-test-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: integration-test-${{ steps.checksum.outputs.checksum }}
+          key: integration-test-go-build-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            integration-test-
+            integration-test-go-build-
 
       - name: Run test environment
         run: make compose

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -31,14 +31,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ steps.checksum.outputs.checksum }}
@@ -51,14 +51,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -29,16 +29,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: unit-test-${{ steps.checksum.outputs.checksum }}
@@ -49,19 +47,6 @@ jobs:
         run: |
           make unit-test-cover
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: unit-test-${{ steps.checksum.outputs.checksum }}
 
       - name: Generate coverage report
         run: go tool cover -html=coverage.out -o coverage.html

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -29,20 +29,39 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      # Use restore-keys to always use a cache that was created with the same
-      # prefix.
-      - name: Cache go modules and the buildcache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
           key: unit-test-${{ steps.checksum.outputs.checksum }}
-          restore-keys: unit-test-
+          restore-keys: |
+            unit-test-
 
       - name: Run tests
         run: |
           make unit-test-cover
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: unit-test-${{ steps.checksum.outputs.checksum }}
 
       - name: Generate coverage report
         run: go tool cover -html=coverage.out -o coverage.html

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -33,15 +33,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: unit-test-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: unit-test-${{ steps.checksum.outputs.checksum }}
+          key: unit-test-go-build-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            unit-test-
+            unit-test-go-build-
 
       - name: Run tests
         run: |

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -56,14 +56,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
@@ -75,14 +75,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -64,9 +64,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
+          key: govulncheck-go-build-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            govulncheck-build-
+            govulncheck-go-build-
 
       - name: Run govulncheck
         run: go tool -modfile tools/go.mod govulncheck -format sarif ./... > results.sarif

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -54,16 +54,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
@@ -73,19 +71,6 @@ jobs:
       - name: Run govulncheck
         run: go tool -modfile tools/go.mod govulncheck -format sarif ./... > results.sarif
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload SARIF report
         if: always()

--- a/.github/workflows/code-scanning.yaml
+++ b/.github/workflows/code-scanning.yaml
@@ -41,10 +41,51 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
-          cache-dependency-path: tools/go.sum
+          cache: false
+
+      - name: Checksum
+        id: checksum
+        run: |
+          checksum=$(
+            {
+              sha256sum tools/go.mod tools/go.sum
+              find . -type f -name "*.go" -print0 | sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
+          restore-keys: |
+            govulncheck-build-
 
       - name: Run govulncheck
         run: go tool -modfile tools/go.mod govulncheck -format sarif ./... > results.sarif
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: govulncheck-go-mod-${{ hashFiles('tools/go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: govulncheck-build-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload SARIF report
         if: always()

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -40,14 +40,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
@@ -67,14 +67,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,16 +38,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
@@ -64,17 +62,3 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
-
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,14 +27,32 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - name: Cache Go modules and build cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Checksum
+        id: checksum
+        run: |
+          checksum=$(
+            {
+              sha256sum go.mod go.sum tools/go.mod tools/go.sum
+              find . -type f -name "*.go" -print0 | sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: copilot-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
-          restore-keys: copilot-go-
+          path: ~/go/pkg/mod
+          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}
+          restore-keys: |
+            copilot-go-build-
 
       - name: Download Go module dependencies
         run: |
@@ -46,3 +64,17 @@ jobs:
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: copilot-go-mod-${{ hashFiles('go.sum', 'tools/go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: copilot-go-build-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/release-ctl.yaml
+++ b/.github/workflows/release-ctl.yaml
@@ -52,14 +52,14 @@ jobs:
 
       - name: Restore Go module cache
         id: go-mod-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Restore Go build cache
         id: go-build-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
@@ -77,14 +77,14 @@ jobs:
 
       - name: Save Go module cache
         if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
       - name: Save Go build cache
         if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ~/.cache/go-build
           key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}

--- a/.github/workflows/release-ctl.yaml
+++ b/.github/workflows/release-ctl.yaml
@@ -54,15 +54,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
+          key: release-ctl-go-mod-${{ hashFiles('go.sum') }}
 
       - name: Cache Go build cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
-          key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
+          key: release-ctl-go-build-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
           restore-keys: |
-            release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-
+            release-ctl-go-build-${{ matrix.goos }}-${{ matrix.goarch }}-
 
       - name: Build CLI binary
         env:

--- a/.github/workflows/release-ctl.yaml
+++ b/.github/workflows/release-ctl.yaml
@@ -33,6 +33,38 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
+
+      - name: Checksum
+        id: checksum
+        run: |
+          checksum=$(
+            {
+              sha256sum go.mod go.sum
+
+              # Exclude _test files; they are not needed to build the code and
+              # they change more often than the actual build inputs.
+              find . -type f -name "*.go" ! -name "*_test.go" -print0 | \
+                sort -z | xargs -0 sha256sum
+            } | sha256sum | awk '{print $1}'
+          )
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Go module cache
+        id: go-mod-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Restore Go build cache
+        id: go-build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/go-build
+          key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
+          restore-keys: |
+            release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-
 
       - name: Build CLI binary
         env:
@@ -42,6 +74,20 @@ jobs:
           CTL_BIN_NAME=locksmithctl-${{ matrix.goos }}-${{ matrix.goarch }}
           [[ "${{ matrix.goos }}" == "windows" ]] && CTL_BIN_NAME="${CTL_BIN_NAME}.exe"
           CTL_BIN_NAME=${CTL_BIN_NAME} make buildctl-release
+
+      - name: Save Go module cache
+        if: steps.go-mod-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+
+      - name: Save Go build cache
+        if: steps.go-build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/go-build
+          key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload binary to release
         env:

--- a/.github/workflows/release-ctl.yaml
+++ b/.github/workflows/release-ctl.yaml
@@ -50,16 +50,14 @@ jobs:
           )
           echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
 
-      - name: Restore Go module cache
-        id: go-mod-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go module cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/go/pkg/mod
           key: go-mod-${{ hashFiles('go.sum') }}
 
-      - name: Restore Go build cache
-        id: go-build-cache
-        uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      - name: Cache Go build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/go-build
           key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
@@ -75,19 +73,6 @@ jobs:
           [[ "${{ matrix.goos }}" == "windows" ]] && CTL_BIN_NAME="${CTL_BIN_NAME}.exe"
           CTL_BIN_NAME=${CTL_BIN_NAME} make buildctl-release
 
-      - name: Save Go module cache
-        if: steps.go-mod-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-
-      - name: Save Go build cache
-        if: steps.go-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/go-build
-          key: release-ctl-${{ matrix.goos }}-${{ matrix.goarch }}-${{ steps.checksum.outputs.checksum }}
 
       - name: Upload binary to release
         env:


### PR DESCRIPTION
## Summary
- split Go module and build caches in GitHub Actions workflows
- use exact module-cache keys and separate build-cache restore/save keys
- avoid carrying stale modules forward through restore-key based cache rollover
