### PR TITLE
feat: standardize Makefile targets to directory-like naming convention

### DIFF
--- a/.github/workflows/callable-build.yaml
+++ b/.github/workflows/callable-build.yaml
@@ -51,4 +51,4 @@ jobs:
         run: make build
 
       - name: Build CLI binary
-        run: make buildctl
+        run: make ctl/build

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -52,10 +52,10 @@ jobs:
             integration-test-go-build-
 
       - name: Run test environment
-        run: make compose
+        run: make compose/up
 
       - name: Run integration tests
-        run: make integration-test-json
+        run: make test/integration-json
 
       - name: Publish integration test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
@@ -81,4 +81,4 @@ jobs:
 
       - name: Teardown test environment
         if: always()
-        run: make compose-down
+        run: make compose/down

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -55,7 +55,7 @@ jobs:
         run: make compose/up
 
       - name: Run integration tests
-        run: make test/integration-json
+        run: make test/integration/json
 
       - name: Publish integration test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/callable-test-integration.yaml
+++ b/.github/workflows/callable-test-integration.yaml
@@ -70,7 +70,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p build
-          make compose-logs > build/integration-test.log
+          make compose/logs > build/integration-test.log
 
       - name: Upload logs
         if: failure()

--- a/.github/workflows/callable-test-load.yaml
+++ b/.github/workflows/callable-test-load.yaml
@@ -61,7 +61,7 @@ jobs:
         if: failure()
         run: |
           mkdir -p build/load-test
-          make compose-logs > build/load-test/compose.log
+          make compose/logs > build/load-test/compose.log
 
       - name: Upload load test artifacts
         if: always()

--- a/.github/workflows/callable-test-load.yaml
+++ b/.github/workflows/callable-test-load.yaml
@@ -52,10 +52,10 @@ jobs:
             load-test-go-build-
 
       - name: Run test environment
-        run: make compose
+        run: make compose/up
 
       - name: Run load test
-        run: make load-test
+        run: make test/load
 
       - name: Collect logs on failure
         if: failure()
@@ -73,4 +73,4 @@ jobs:
 
       - name: Teardown test environment
         if: always()
-        run: make compose-down
+        run: make compose/down

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -45,13 +45,13 @@ jobs:
 
       - name: Run tests
         run: |
-          make unit-test-cover
+          make test/unit-cover
 
       - name: Generate coverage report
-        run: go tool cover -html=coverage.out -o coverage.html
+        run: go tool cover -html=build/coverage.out -o build/coverage.html
 
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-coverage-report
-          path: coverage.html
+          path: build/coverage.html

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run tests
         run: |
-          make test/unit-cover
+          make test/unit/cover
 
       - name: Generate coverage report
         run: go tool cover -html=build/coverage.out -o build/coverage.html
@@ -53,5 +53,5 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: go-coverage-report
+          name: go-coverage/report
           path: build/coverage.html

--- a/.github/workflows/callable-test-unit.yaml
+++ b/.github/workflows/callable-test-unit.yaml
@@ -53,5 +53,5 @@ jobs:
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: go-coverage/report
+          name: go-coverage-report
           path: build/coverage.html

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -58,7 +58,7 @@ jobs:
           go mod download -modfile tools/go.mod
 
       - name: Install golangci-lint
-        run: make install-lint
+        run: make install/lint
 
       - name: Warm up govulncheck
         run: go tool -modfile tools/go.mod govulncheck -version

--- a/.github/workflows/release-ctl.yaml
+++ b/.github/workflows/release-ctl.yaml
@@ -71,7 +71,7 @@ jobs:
         run: |
           CTL_BIN_NAME=locksmithctl-${{ matrix.goos }}-${{ matrix.goarch }}
           [[ "${{ matrix.goos }}" == "windows" ]] && CTL_BIN_NAME="${CTL_BIN_NAME}.exe"
-          CTL_BIN_NAME=${CTL_BIN_NAME} make buildctl-release
+          CTL_BIN_NAME=${CTL_BIN_NAME} make ctl/build/release
 
 
       - name: Upload binary to release

--- a/Makefile
+++ b/Makefile
@@ -10,92 +10,114 @@ GOBIN ?= $(GOPATH)/bin
 
 .PHONY: build
 build:
-	mkdir -p build
-	go build -o build/locksmith
+mkdir -p build
+go build -o build/locksmith
 
-build-image:
-	docker build -t ghcr.io/maansaake/locksmith:local .
+compose/down:
+docker compose \
+-f test/compose/compose.yaml \
+down
 
-buildctl:
-	mkdir -p build
-	go build -o build/locksmithctl ./cmd/locksmithctl
+compose/logs:
+docker compose -f test/compose/compose.yaml logs
 
-buildctl-release:
-	mkdir -p build
-	go build -trimpath -ldflags="-s -w" -o build/${CTL_BIN_NAME} ./cmd/locksmithctl
+compose/logs-follow:
+docker compose -f test/compose/compose.yaml logs -f
 
-lint:
-	golangci-lint run --fix
+compose/up:
+LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+docker compose \
+-f test/compose/compose.yaml \
+up \
+-d
 
-install-lint:
-	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
+coverage:
+@go tool cover -html=build/coverage.out -o build/coverage.html
+@go tool cover -func=build/coverage.out | awk 'END {print $$3}'
 
-govulncheck:
-	go tool -modfile tools/go.mod govulncheck ./...
+coverage/report:
+@go tool cover -html=build/coverage.out -o build/coverage.html
+@echo "### Code Coverage: $$(go tool cover -func=build/coverage.out | awk '/^total:/{print $$3}')"
 
-unit-test:
-	go test ./pkg/... ./internal/... -failfast
+ctl/build:
+mkdir -p build
+go build -o build/locksmithctl ./cmd/locksmithctl
 
-unit-test-cover:
-	go test ./pkg/... ./internal/... -failfast -coverprofile=coverage.out
+ctl/build-release:
+mkdir -p build
+go build -trimpath -ldflags="-s -w" -o build/${CTL_BIN_NAME} ./cmd/locksmithctl
 
-integration-test:
-	go test ./test/integration/... -failfast -count=1 -v
+ctl/run: ctl/build
+./build/${CTL_BIN_NAME}
 
-integration-test-json:
-	mkdir -p build
-	go test ./test/integration/... -failfast -count=1 -v -json > build/integration-test-output.json
+docker/build:
+docker build -t ghcr.io/maansaake/locksmith:local .
 
-load-test:
-	rm -rf build/load-test
-	mkdir -p build/load-test
-	go run ./test/load cli \
-		--duration ${LOAD_TEST_DURATION} \
-		--report-path build/load-test/report.yaml \
-		--locksmith-load.host ${LOCKSMITH_HOST} \
-		--locksmith-load.port ${LOCKSMITH_PORT}
-	go run ./test/load/validate \
-		-error-log build/load-test/error.log \
-		-report build/load-test/report.yaml
+docker/logs:
+@docker logs locksmith
 
-compose:
-	LOCKSMITH_PORT=${LOCKSMITH_PORT} \
-		docker compose \
-		-f test/compose/compose.yaml \
-		up \
-		-d
+docker/run: docker/build
+docker run -d \
+-p ${LOCKSMITH_METRICS_PORT}:${LOCKSMITH_METRICS_PORT} \
+-p ${LOCKSMITH_PORT}:${LOCKSMITH_PORT} \
+-e LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+-e LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
+-e OTEL_METRICS_EXPORTER=prometheus \
+-e OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0 \
+-e OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
+--rm \
+--name locksmith \
+ghcr.io/maansaake/locksmith:local
 
-compose-down:
-	docker compose \
-		-f test/compose/compose.yaml \
-		down
+docker/stop:
+@docker stop locksmith || true
 
-compose-logs:
-	docker compose -f test/compose/compose.yaml logs
-
-compose-logs-f:
-	docker compose -f test/compose/compose.yaml logs -f
+install/lint:
+curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
 
 run: build
-	LOCKSMITH_PORT=${LOCKSMITH_PORT} \
-		LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
-		OTEL_METRICS_EXPORTER=prometheus \
+LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
+OTEL_METRICS_EXPORTER=prometheus \
     OTEL_EXPORTER_PROMETHEUS_HOST=localhost \
     OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
-		./build/locksmith
+./build/locksmith
 
-run-docker: build-image
-	docker run -d \
-		-p ${LOCKSMITH_METRICS_PORT}:${LOCKSMITH_METRICS_PORT} \
-		-p ${LOCKSMITH_PORT}:${LOCKSMITH_PORT} \
-		-e LOCKSMITH_PORT=${LOCKSMITH_PORT} \
-		-e LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
-		-e OTEL_METRICS_EXPORTER=prometheus \
-		-e OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0 \
-		-e OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
-		--rm \
-		--name locksmith \
-		ghcr.io/maansaake/locksmith:local
+static-analysis/lint:
+golangci-lint run --fix
 
-runctl: buildctl
-	./build/${CTL_BIN_NAME}
+static-analysis/vulncheck:
+go tool -modfile tools/go.mod govulncheck ./...
+
+static-analysis/vulncheck-sarif:
+mkdir -p build
+go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/govulncheck-report.sarif
+
+test/integration:
+go test ./test/integration/... -failfast -count=1 -v
+
+test/integration-json:
+mkdir -p build
+go test ./test/integration/... -failfast -count=1 -v -json > build/integration-test-output.json
+
+test/load:
+rm -rf build/load-test
+mkdir -p build/load-test
+go run ./test/load cli \
+--duration ${LOAD_TEST_DURATION} \
+--report-path build/load-test/report.yaml \
+--locksmith-load.host ${LOCKSMITH_HOST} \
+--locksmith-load.port ${LOCKSMITH_PORT}
+go run ./test/load/validate \
+-error-log build/load-test/error.log \
+-report build/load-test/report.yaml
+
+test/unit:
+go test ./pkg/... ./internal/... -failfast
+
+test/unit-cover:
+go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out
+
+test/unit-json:
+mkdir -p build
+go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out -v -json > build/unit-test-output.json

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ test/unit:
 	go test ./pkg/... ./internal/... -failfast
 
 test/unit-cover:
+	mkdir -p build
 	go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out
 
 test/unit-json:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ compose/down:
 compose/logs:
 	docker compose -f test/compose/compose.yaml logs
 
-compose/logs-follow:
+compose/logs/follow:
 	docker compose -f test/compose/compose.yaml logs -f
 
 compose/up:
@@ -43,7 +43,7 @@ ctl/build:
 	mkdir -p build
 	go build -o build/locksmithctl ./cmd/locksmithctl
 
-ctl/build-release:
+ctl/build/release:
 	mkdir -p build
 	go build -trimpath -ldflags="-s -w" -o build/${CTL_BIN_NAME} ./cmd/locksmithctl
 
@@ -89,14 +89,14 @@ static-analysis/lint:
 static-analysis/vulncheck:
 	go tool -modfile tools/go.mod govulncheck ./...
 
-static-analysis/vulncheck-sarif:
+static-analysis/vulncheck/sarif:
 	mkdir -p build
 	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/govulncheck-report.sarif
 
 test/integration:
 	go test ./test/integration/... -failfast -count=1 -v
 
-test/integration-json:
+test/integration/json:
 	mkdir -p build
 	go test ./test/integration/... -failfast -count=1 -v -json > build/integration-test-output.json
 
@@ -115,10 +115,10 @@ test/load:
 test/unit:
 	go test ./pkg/... ./internal/... -failfast
 
-test/unit-cover:
+test/unit/cover:
 	mkdir -p build
 	go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out
 
-test/unit-json:
+test/unit/json:
 	mkdir -p build
 	go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out -v -json > build/unit-test-output.json

--- a/Makefile
+++ b/Makefile
@@ -10,114 +10,114 @@ GOBIN ?= $(GOPATH)/bin
 
 .PHONY: build
 build:
-mkdir -p build
-go build -o build/locksmith
+	mkdir -p build
+	go build -o build/locksmith
 
 compose/down:
-docker compose \
--f test/compose/compose.yaml \
-down
+	docker compose \
+	-f test/compose/compose.yaml \
+	down
 
 compose/logs:
-docker compose -f test/compose/compose.yaml logs
+	docker compose -f test/compose/compose.yaml logs
 
 compose/logs-follow:
-docker compose -f test/compose/compose.yaml logs -f
+	docker compose -f test/compose/compose.yaml logs -f
 
 compose/up:
-LOCKSMITH_PORT=${LOCKSMITH_PORT} \
-docker compose \
--f test/compose/compose.yaml \
-up \
--d
+	LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+	docker compose \
+	-f test/compose/compose.yaml \
+	up \
+	-d
 
 coverage:
-@go tool cover -html=build/coverage.out -o build/coverage.html
-@go tool cover -func=build/coverage.out | awk 'END {print $$3}'
+	@go tool cover -html=build/coverage.out -o build/coverage.html
+	@go tool cover -func=build/coverage.out | awk 'END {print $$3}'
 
 coverage/report:
-@go tool cover -html=build/coverage.out -o build/coverage.html
-@echo "### Code Coverage: $$(go tool cover -func=build/coverage.out | awk '/^total:/{print $$3}')"
+	@go tool cover -html=build/coverage.out -o build/coverage.html
+	@echo "### Code Coverage: $$(go tool cover -func=build/coverage.out | awk '/^total:/{print $$3}')"
 
 ctl/build:
-mkdir -p build
-go build -o build/locksmithctl ./cmd/locksmithctl
+	mkdir -p build
+	go build -o build/locksmithctl ./cmd/locksmithctl
 
 ctl/build-release:
-mkdir -p build
-go build -trimpath -ldflags="-s -w" -o build/${CTL_BIN_NAME} ./cmd/locksmithctl
+	mkdir -p build
+	go build -trimpath -ldflags="-s -w" -o build/${CTL_BIN_NAME} ./cmd/locksmithctl
 
 ctl/run: ctl/build
-./build/${CTL_BIN_NAME}
+	./build/${CTL_BIN_NAME}
 
 docker/build:
-docker build -t ghcr.io/maansaake/locksmith:local .
+	docker build -t ghcr.io/maansaake/locksmith:local .
 
 docker/logs:
-@docker logs locksmith
+	@docker logs locksmith
 
 docker/run: docker/build
-docker run -d \
--p ${LOCKSMITH_METRICS_PORT}:${LOCKSMITH_METRICS_PORT} \
--p ${LOCKSMITH_PORT}:${LOCKSMITH_PORT} \
--e LOCKSMITH_PORT=${LOCKSMITH_PORT} \
--e LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
--e OTEL_METRICS_EXPORTER=prometheus \
--e OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0 \
--e OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
---rm \
---name locksmith \
+	docker run -d \
+	-p ${LOCKSMITH_METRICS_PORT}:${LOCKSMITH_METRICS_PORT} \
+	-p ${LOCKSMITH_PORT}:${LOCKSMITH_PORT} \
+	-e LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+	-e LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
+	-e OTEL_METRICS_EXPORTER=prometheus \
+	-e OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0 \
+	-e OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
+	--rm \
+	--name locksmith \
 ghcr.io/maansaake/locksmith:local
 
 docker/stop:
-@docker stop locksmith || true
+	@docker stop locksmith || true
 
 install/lint:
-curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(GOBIN) v2.12.2
 
 run: build
-LOCKSMITH_PORT=${LOCKSMITH_PORT} \
-LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
-OTEL_METRICS_EXPORTER=prometheus \
-    OTEL_EXPORTER_PROMETHEUS_HOST=localhost \
-    OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
-./build/locksmith
+	LOCKSMITH_PORT=${LOCKSMITH_PORT} \
+	LOCKSMITH_OBSERVABILITY=${LOCKSMITH_OBSERVABILITY} \
+	OTEL_METRICS_EXPORTER=prometheus \
+	    OTEL_EXPORTER_PROMETHEUS_HOST=localhost \
+	    OTEL_EXPORTER_PROMETHEUS_PORT=${LOCKSMITH_METRICS_PORT} \
+	./build/locksmith
 
 static-analysis/lint:
-golangci-lint run --fix
+	golangci-lint run --fix
 
 static-analysis/vulncheck:
-go tool -modfile tools/go.mod govulncheck ./...
+	go tool -modfile tools/go.mod govulncheck ./...
 
 static-analysis/vulncheck-sarif:
-mkdir -p build
-go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/govulncheck-report.sarif
+	mkdir -p build
+	go tool -modfile tools/go.mod govulncheck -format sarif ./... > build/govulncheck-report.sarif
 
 test/integration:
-go test ./test/integration/... -failfast -count=1 -v
+	go test ./test/integration/... -failfast -count=1 -v
 
 test/integration-json:
-mkdir -p build
-go test ./test/integration/... -failfast -count=1 -v -json > build/integration-test-output.json
+	mkdir -p build
+	go test ./test/integration/... -failfast -count=1 -v -json > build/integration-test-output.json
 
 test/load:
-rm -rf build/load-test
-mkdir -p build/load-test
-go run ./test/load cli \
---duration ${LOAD_TEST_DURATION} \
---report-path build/load-test/report.yaml \
---locksmith-load.host ${LOCKSMITH_HOST} \
---locksmith-load.port ${LOCKSMITH_PORT}
-go run ./test/load/validate \
--error-log build/load-test/error.log \
--report build/load-test/report.yaml
+	rm -rf build/load-test
+	mkdir -p build/load-test
+	go run ./test/load cli \
+	--duration ${LOAD_TEST_DURATION} \
+	--report-path build/load-test/report.yaml \
+	--locksmith-load.host ${LOCKSMITH_HOST} \
+	--locksmith-load.port ${LOCKSMITH_PORT}
+	go run ./test/load/validate \
+	-error-log build/load-test/error.log \
+	-report build/load-test/report.yaml
 
 test/unit:
-go test ./pkg/... ./internal/... -failfast
+	go test ./pkg/... ./internal/... -failfast
 
 test/unit-cover:
-go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out
+	go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out
 
 test/unit-json:
-mkdir -p build
-go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out -v -json > build/unit-test-output.json
+	mkdir -p build
+	go test ./pkg/... ./internal/... -failfast -coverprofile=build/coverage.out -v -json > build/unit-test-output.json


### PR DESCRIPTION
Adopts the standard tool-first directory-like naming convention across the Makefile and updates all workflow files.

**Renames:**
| Old | New |
|---|---|
| `build-image` | `docker/build` |
| `run-docker` | `docker/run` |
| `buildctl` | `ctl/build` |
| `buildctl-release` | `ctl/build-release` |
| `runctl` | `ctl/run` |
| `lint` | `static-analysis/lint` |
| `govulncheck` | `static-analysis/vulncheck` |
| `install-lint` | `install/lint` |
| `unit-test` | `test/unit` |
| `unit-test-cover` | `test/unit-cover` |
| `integration-test` | `test/integration` |
| `integration-test-json` | `test/integration-json` |
| `load-test` | `test/load` |
| `compose` | `compose/up` |
| `compose-down` | `compose/down` |
| `compose-logs` | `compose/logs` |
| `compose-logs-f` | `compose/logs-follow` |

**New standard targets added:**
- `test/unit-json`
- `coverage`
- `coverage/report`
- `static-analysis/vulncheck-sarif`
- `docker/stop`
- `docker/logs`

**Workflow files updated:** `callable-build.yaml`, `callable-test-integration.yaml`, `callable-test-load.yaml`, `copilot-setup-steps.yml`