### PR TITLE
Handle UNKNOWN merge state for Dependabot PRs

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -41,6 +41,9 @@ jobs:
               if [ "$merge_state" = "BEHIND" ]; then
                 echo "PR #$pr is behind main, triggering Dependabot rebase"
                 gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+              elif [ "$merge_state" = "UNKNOWN" ]; then
+                echo "PR #$pr state UNKNOWN, triggering Dependabot rebase anyway to be safe"
+                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi


### PR DESCRIPTION
Trigger a `@dependabot rebase` comment when `mergeStateStatus` is `UNKNOWN` in addition to `BEHIND`, matching the behaviour already in [`maansaake/github-actions-help`](https://github.com/maansaake/github-actions-help).

GitHub occasionally returns `UNKNOWN` while it is still computing the merge state. Without this change, Dependabot PRs in that transient state are silently skipped and may never get rebased.