### PR TITLE
Handle UNKNOWN merge state and fix Dependabot comment token

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VANILLA_GH_TOKEN: ${{ github.token }}
         run: |
           gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
             --jq '.[] | "\(.number) \(.author.login)"' | \
@@ -40,10 +41,10 @@ jobs:
                 --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
               if [ "$merge_state" = "BEHIND" ]; then
                 echo "PR #$pr is behind main, triggering Dependabot rebase"
-                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               elif [ "$merge_state" = "UNKNOWN" ]; then
                 echo "PR #$pr state UNKNOWN, triggering Dependabot rebase anyway to be safe"
-                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi


### PR DESCRIPTION
Trigger a `@dependabot rebase` comment when `mergeStateStatus` is `UNKNOWN` in addition to `BEHIND`, matching the behaviour already in [`maansaake/github-actions-help`](https://github.com/maansaake/github-actions-help).

GitHub occasionally returns `UNKNOWN` while it is still computing the merge state. Without this change, Dependabot PRs in that transient state are silently skipped and may never get rebased.

Additionally, the `@dependabot rebase` comment is now posted using the vanilla `github.token` (`github-actions[bot]`) rather than the Jeeves app token. Dependabot only accepts commands from accounts with push access; `github-actions[bot]` satisfies that requirement where the Jeeves token does not.