### PR TITLE
fix: use jeeves token for gh pr update-branch rebase

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -44,7 +44,7 @@ jobs:
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi
-                        else
+            else
               gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
             fi
           done

--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -26,29 +26,25 @@ jobs:
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DEPENDABOT_REBASE_TOKEN: ${{ secrets.DEPENDABOT_REBASE_TOKEN }}
+          UPDATE_BRANCH_TOKEN: ${{ github.token }}
         run: |
           gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
             --jq '.[] | "\(.number) \(.author.login)"' | \
           while IFS=' ' read -r pr author; do
             echo "Checking PR #$pr (author: $author)..."
             if [ "$author" = "app/dependabot" ]; then
-              # Trigger Dependabot to rebase its own branch rather than pushing directly with
-              # the Jeeves bot token. If Jeeves pushes, dependabot/fetch-metadata fails with
-              # "PR is not from Dependabot" on the resulting synchronize event, which prevents
-              # Jeeves from re-approving and re-enabling auto-merge on that PR.
+              # Use github.token (github-actions[bot]) rather than the Jeeves token so that
+              # Jeeves (mr-jeeves[bot]) remains free to approve the resulting synchronize event.
+              # GitHub blocks a bot from approving commits it pushed itself.
               merge_state=$(gh pr view "$pr" --repo "${{ github.repository }}" \
                 --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
-              if [ "$merge_state" = "BEHIND" ]; then
-                echo "PR #$pr is behind main, triggering Dependabot rebase"
-                GH_TOKEN="$DEPENDABOT_REBASE_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
-              elif [ "$merge_state" = "UNKNOWN" ]; then
-                echo "PR #$pr state UNKNOWN, triggering Dependabot rebase anyway to be safe"
-                GH_TOKEN="$DEPENDABOT_REBASE_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+              if [ "$merge_state" = "BEHIND" ] || [ "$merge_state" = "UNKNOWN" ]; then
+                echo "PR #$pr merge state is '$merge_state', rebasing via github-actions[bot]"
+                GH_TOKEN="$UPDATE_BRANCH_TOKEN" gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi
-            else
+                        else
               gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
             fi
           done

--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          VANILLA_GH_TOKEN: ${{ github.token }}
+          DEPENDABOT_REBASE_TOKEN: ${{ secrets.DEPENDABOT_REBASE_TOKEN }}
         run: |
           gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
             --jq '.[] | "\(.number) \(.author.login)"' | \
@@ -41,10 +41,10 @@ jobs:
                 --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
               if [ "$merge_state" = "BEHIND" ]; then
                 echo "PR #$pr is behind main, triggering Dependabot rebase"
-                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$DEPENDABOT_REBASE_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               elif [ "$merge_state" = "UNKNOWN" ]; then
                 echo "PR #$pr state UNKNOWN, triggering Dependabot rebase anyway to be safe"
-                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$DEPENDABOT_REBASE_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi

--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VANILLA_GH_TOKEN: ${{ github.token }}
         run: |
           gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
             --jq '.[] | "\(.number) \(.author.login)"' | \
@@ -40,10 +41,10 @@ jobs:
                 --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
               if [ "$merge_state" = "BEHIND" ]; then
                 echo "PR #$pr is behind main, triggering Dependabot rebase"
-                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               elif [ "$merge_state" = "UNKNOWN" ]; then
                 echo "PR #$pr state UNKNOWN, triggering Dependabot rebase anyway to be safe"
-                gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
+                GH_TOKEN="$VANILLA_GH_TOKEN" gh pr comment --repo "${{ github.repository }}" "$pr" --body "@dependabot rebase" || true
               else
                 echo "PR #$pr merge state is '$merge_state', no update needed"
               fi

--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -16,35 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'maansaake/locksmith'
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ secrets.JEEVES_APP_ID }}
-          private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
-
       - name: Update out-of-date PR branches
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          UPDATE_BRANCH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr list --repo "${{ github.repository }}" --base main --state open --json number,author \
-            --jq '.[] | "\(.number) \(.author.login)"' | \
-          while IFS=' ' read -r pr author; do
-            echo "Checking PR #$pr (author: $author)..."
-            if [ "$author" = "app/dependabot" ]; then
-              # Use github.token (github-actions[bot]) rather than the Jeeves token so that
-              # Jeeves (mr-jeeves[bot]) remains free to approve the resulting synchronize event.
-              # GitHub blocks a bot from approving commits it pushed itself.
-              merge_state=$(gh pr view "$pr" --repo "${{ github.repository }}" \
-                --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "ERROR")
-              if [ "$merge_state" = "BEHIND" ] || [ "$merge_state" = "UNKNOWN" ]; then
-                echo "PR #$pr merge state is '$merge_state', rebasing via github-actions[bot]"
-                GH_TOKEN="$UPDATE_BRANCH_TOKEN" gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
-              else
-                echo "PR #$pr merge state is '$merge_state', no update needed"
-              fi
-            else
-              gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
-            fi
+          gh pr list --repo "${{ github.repository }}" --base main --state open --json number \
+            --jq '.[].number' | \
+          while read -r pr; do
+            echo "Updating PR #$pr..."
+            gh pr update-branch --rebase --repo "${{ github.repository }}" "$pr" || true
           done

--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -16,9 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'maansaake/locksmith'
     steps:
+      - name: Generate Jeeves app token
+        id: jeeves-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JEEVES_APP_ID }}
+          private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
       - name: Update out-of-date PR branches
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.jeeves-token.outputs.token }}
         run: |
           gh pr list --repo "${{ github.repository }}" --base main --state open --json number \
             --jq '.[].number' | \


### PR DESCRIPTION
Switch back to Jeeves app token for `gh pr update-branch --rebase` so that the rebase push triggers downstream workflows (e.g. Jeeves's auto-approval). Using `github.token` caused pushes from `github-actions[bot]` which does not trigger other workflow runs.

The `@dependabot rebase` comment approach is dropped entirely — the CLI `gh pr update-branch --rebase` is used directly instead.