### PR TITLE
chore: sync workflows with github-actions-help reference

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yaml
+++ b/.github/workflows/auto-update-pr-branches.yaml
@@ -22,7 +22,6 @@ jobs:
         with:
           client-id: ${{ secrets.JEEVES_APP_ID }}
           private-key: ${{ secrets.JEEVES_APP_PRIVATE_KEY }}
-
       - name: Update out-of-date PR branches
         env:
           GH_TOKEN: ${{ steps.jeeves-token.outputs.token }}

--- a/.github/workflows/dependabot-auto-approve.yaml
+++ b/.github/workflows/dependabot-auto-approve.yaml
@@ -43,13 +43,7 @@ jobs:
           fi
 
       - name: Re-approve after branch update if auto-merge was already configured
-        # Runs on synchronize events where step 4 would be skipped — i.e. when fetch-metadata
-        # either failed (outcome=failure) or returned an empty/unexpected update-type.
-        # The auto-merge check inside the script guards against re-approving major updates.
-        if: >-
-          github.event.action == 'synchronize' &&
-          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
-          steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        if: github.event.action == 'synchronize' && steps.metadata.outcome == 'failure'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Syncs workflows to match the reference in `maansaake/github-actions-help`.

**Changes:**
- `dependabot-auto-approve.yaml`: Re-approve step's `if` condition reverted to `steps.metadata.outcome == 'failure'`
- `auto-update-pr-branches.yaml`: Removed extra blank line between steps